### PR TITLE
ignore lines that start with a ‘#’

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,6 +80,7 @@ function resolveAll (links, cb) {
   if (!missing) return cb(null, [])
 
   for (var i = 0; i < links.length; i++) {
+    if (links[i].startsWith('#')) continue
     datDns.resolveName(links[i], function (_, key) {
       keys.push(key)
       if (!--missing) cb(null, keys.filter(Boolean))


### PR DESCRIPTION
I don't speak js, but the change “works for me”: If merged, hypercored will ignore lines in the `feeds` file that starts with a ‘#’.

Closes #7 
